### PR TITLE
CPLYTM-497: feat: adds Settings to PluginManager operations

### DIFF
--- a/framework/reporter_test.go
+++ b/framework/reporter_test.go
@@ -13,11 +13,11 @@ import (
 	"time"
 
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
-	"github.com/oscal-compass/compliance-to-policy-go/v2/framework/config"
-	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
 	"github.com/oscal-compass/oscal-sdk-go/generators"
 	"github.com/oscal-compass/oscal-sdk-go/settings"
 	"github.com/stretchr/testify/require"
+
+	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
 )
 
 var (
@@ -94,7 +94,7 @@ func TestReporter_FindControls(t *testing.T) {
 	includeControls := *foundControls.ControlSelections[0].IncludeControls
 
 	require.Len(t, foundControls.ControlSelections, 1)
-	require.Equal(t, includeControls[0].ControlId, implementationSettings.AllControls()[0])
+	require.Equal(t, includeControls[0], implementationSettings.AllControls()[0])
 }
 
 func TestReporter_ToOscalObservation(t *testing.T) {
@@ -193,15 +193,4 @@ func prepImplementationSettings(t *testing.T, testComp oscalTypes.ComponentDefin
 
 	return *implementationSettings
 
-}
-
-func prepConfig(t *testing.T) *config.C2PConfig {
-	cfg := config.DefaultConfig()
-	cfg.PluginDir = "."
-	file, err := os.Open(testDataPath)
-	require.NoError(t, err)
-	definition, err := generators.NewComponentDefinition(file)
-	require.NoError(t, err)
-	cfg.ComponentDefinitions = append(cfg.ComponentDefinitions, *definition)
-	return cfg
 }

--- a/go.mod
+++ b/go.mod
@@ -296,4 +296,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-replace github.com/oscal-compass/oscal-sdk-go => github.com/jpower432/oscal-sdk-go v0.0.0-20250122232134-3f0661c3946b
+replace github.com/oscal-compass/oscal-sdk-go => github.com/complytime/oscal-sdk-go v0.0.0-20250125144051-7723a7b6b06b

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUo
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
+github.com/complytime/oscal-sdk-go v0.0.0-20250125144051-7723a7b6b06b h1:F3tqX70f1WSdGrOnSFlc0AU/QiGxBKw6MfmC/ZX0wdE=
+github.com/complytime/oscal-sdk-go v0.0.0-20250125144051-7723a7b6b06b/go.mod h1:O922y+Za9/ez0jKTR3/97BilPnrjabtFJ6rCVhHk37s=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1/go.mod h1:gr2RNwukQ/S9Nv33Lt6UC7xEx58C+LHRdoqbEKjz1Kk=
 github.com/coreos/go-oidc/v3 v3.10.0 h1:tDnXHnLyiTVyT/2zLDGj09pFPkhND8Gl8lnTRhoEaJU=
@@ -490,8 +492,6 @@ github.com/jmhodges/clock v1.2.0 h1:eq4kys+NI0PLngzaHEe7AmPT90XMGIEySD1JfV1PDIs=
 github.com/jmhodges/clock v1.2.0/go.mod h1:qKjhA7x7u/lQpPB1XAqX1b1lCI/w3/fNuYpI/ZjLynI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/jpower432/oscal-sdk-go v0.0.0-20250122232134-3f0661c3946b h1:blT482UCu7rbakdxnpplqfOqEFnSjVJrdtI/4beqP78=
-github.com/jpower432/oscal-sdk-go v0.0.0-20250122232134-3f0661c3946b/go.mod h1:O922y+Za9/ez0jKTR3/97BilPnrjabtFJ6rCVhHk37s=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=


### PR DESCRIPTION
To allow customization based on implementations for specific compliance frameworks, a Settings input has been added to GeneratePolicy and AggregateResults methods to alter the RuleSets passed to plugins based on settings from a given control implementation.