### PR TITLE
fix: reporter no rule for check

### DIFF
--- a/framework/reporter.go
+++ b/framework/reporter.go
@@ -234,7 +234,10 @@ func (r *Reporter) GenerateAssessmentResults(ctx context.Context, planHref strin
 			rule, err := r.rulesStore.GetByCheckID(ctx, observationByCheck.CheckID)
 			if err != nil {
 				if !errors.Is(err, rules.ErrRuleNotFound) {
-					return assessmentResults, fmt.Errorf("failed to convert observation for check: %w", err)
+					return assessmentResults, fmt.Errorf("failed to convert observation for check %v: %w", observationByCheck.CheckID, err)
+				} else {
+					r.log.Warn(fmt.Sprintf("skipping observation for check %v: %v", observationByCheck.CheckID, err))
+					continue
 				}
 			}
 
@@ -279,5 +282,4 @@ func (r *Reporter) GenerateAssessmentResults(ctx context.Context, planHref strin
 	}
 
 	return assessmentResults, nil
-
 }


### PR DESCRIPTION
The generateFindings function should skip a check if no matching rule was found from the rule store.  The function will log a warning message for the user's awareness.  