### PR TITLE
CPLYTM-610: fix: error handling for validation component

### DIFF
--- a/framework/manager.go
+++ b/framework/manager.go
@@ -108,7 +108,8 @@ func (m *PluginManager) GeneratePolicy(ctx context.Context, pluginSet map[string
 	for providerId, policyPlugin := range pluginSet {
 		componentTitle, ok := m.pluginIdMap[providerId]
 		if !ok {
-			return fmt.Errorf("missing title for provider %s", providerId)
+			m.log.Info(fmt.Sprintf("skipping %s provider: missing validation component", providerId))
+			continue
 		}
 		m.log.Debug(fmt.Sprintf("Generating policy for provider %s", providerId))
 

--- a/framework/manager.go
+++ b/framework/manager.go
@@ -108,7 +108,7 @@ func (m *PluginManager) GeneratePolicy(ctx context.Context, pluginSet map[string
 	for providerId, policyPlugin := range pluginSet {
 		componentTitle, ok := m.pluginIdMap[providerId]
 		if !ok {
-			m.log.Info(fmt.Sprintf("skipping %s provider: missing validation component", providerId))
+			m.log.Warn(fmt.Sprintf("skipping %s provider: missing validation component", providerId))
 			continue
 		}
 		m.log.Debug(fmt.Sprintf("Generating policy for provider %s", providerId))


### PR DESCRIPTION
When generating a policy, the validation component title is necessary.

However, in a scenario where multiple plugins are available, it could be valid that there is no validation component for all plugins. This PR changes the behavior to only inform instead of return error.

It was tested with ComplyTime using the structure of https://github.com/complytime/complytime-demos where the VM was populated with a Component Definition without a validation component.

Before the change:
```
[ansible@rhel9 ~]$ complytime generate
INFO Searching for plugins in /home/ansible/.config/complytime/plugins
INFO configuring client automatic mTLS
INFO openscap-plugin: configuring server automatic mTLS timestamp=2025-03-12T09:19:43.409Z
INFO plugin process exited plugin=/home/ansible/.config/complytime/plugins/openscap-plugin id=10503
Usage:
  complytime generate [flags]

Examples:
complytime generate

Flags:
  -h, --help               help for generate
  -w, --workspace string   workspace to use for artifact generation (default "./complytime")

Global Flags:
  -d, --debug   output debug logs

ERROR error running complytime: missing title for provider openscap
```

After the change:
```
[ansible@rhel9 ~]$ complytime generate
INFO Searching for plugins in /home/ansible/.config/complytime/plugins
INFO configuring client automatic mTLS
INFO openscap-plugin: configuring server automatic mTLS timestamp=2025-03-12T10:46:15.905Z
WARN skipping openscap provider: missing validation component
INFO Policy generation completed successfully.
INFO plugin process exited plugin=/home/ansible/.config/complytime/plugins/openscap-plugin id=19500
```
Some refinement on ComplyTime messages will be necessary once this change is concluded.